### PR TITLE
Fix compilation on Zig master

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,20 +5,3 @@ Note: for testing, renode supports arduino nano 33 BLE
 == What version of Zig to use
 
 Right now we are following https://ziglang.org/download/[master], but once 0.11.0 is released, we will be switching to the latest stable version of Zig.
-
-== FYI: LLVM issues
-
-Currently LLVM is having trouble lowering AVR when this is built in debug mode:
-
-[source]
-----
-LLVM Emit Object... Don't know how to custom lower this!
-UNREACHABLE executed at /Users/mattnite/code/llvm-project-15/llvm/lib/Target/AVR/AVRISelLowering.cpp:842!
-----
-
-for now always build in release small:
-
-[source]
-----
-zig build -Doptimize=ReleaseSmall
-----

--- a/src/chips/ATmega328P.zig
+++ b/src/chips/ATmega328P.zig
@@ -67,39 +67,39 @@ pub const devices = struct {
 
         pub const peripherals = struct {
             ///  Fuses
-            pub const FUSE = @intToPtr(*volatile types.peripherals.FUSE, 0x0);
+            pub const FUSE = @as(*volatile types.peripherals.FUSE, @ptrFromInt(0x0));
             ///  Lockbits
-            pub const LOCKBIT = @intToPtr(*volatile types.peripherals.LOCKBIT, 0x0);
+            pub const LOCKBIT = @as(*volatile types.peripherals.LOCKBIT, @ptrFromInt(0x0));
             ///  I/O Port
-            pub const PORTB = @intToPtr(*volatile types.peripherals.PORT.PORTB, 0x23);
+            pub const PORTB = @as(*volatile types.peripherals.PORT.PORTB, @ptrFromInt(0x23));
             ///  I/O Port
-            pub const PORTC = @intToPtr(*volatile types.peripherals.PORT.PORTC, 0x26);
+            pub const PORTC = @as(*volatile types.peripherals.PORT.PORTC, @ptrFromInt(0x26));
             ///  I/O Port
-            pub const PORTD = @intToPtr(*volatile types.peripherals.PORT.PORTD, 0x29);
+            pub const PORTD = @as(*volatile types.peripherals.PORT.PORTD, @ptrFromInt(0x29));
             ///  Timer/Counter, 8-bit
-            pub const TC0 = @intToPtr(*volatile types.peripherals.TC8.TC0, 0x35);
+            pub const TC0 = @as(*volatile types.peripherals.TC8.TC0, @ptrFromInt(0x35));
             ///  Timer/Counter, 16-bit
-            pub const TC1 = @intToPtr(*volatile types.peripherals.TC16.TC1, 0x36);
+            pub const TC1 = @as(*volatile types.peripherals.TC16.TC1, @ptrFromInt(0x36));
             ///  Timer/Counter, 8-bit Async
-            pub const TC2 = @intToPtr(*volatile types.peripherals.TC8_ASYNC.TC2, 0x37);
+            pub const TC2 = @as(*volatile types.peripherals.TC8_ASYNC.TC2, @ptrFromInt(0x37));
             ///  External Interrupts
-            pub const EXINT = @intToPtr(*volatile types.peripherals.EXINT, 0x3b);
+            pub const EXINT = @as(*volatile types.peripherals.EXINT, @ptrFromInt(0x3b));
             ///  CPU Registers
-            pub const CPU = @intToPtr(*volatile types.peripherals.CPU, 0x3e);
+            pub const CPU = @as(*volatile types.peripherals.CPU, @ptrFromInt(0x3e));
             ///  EEPROM
-            pub const EEPROM = @intToPtr(*volatile types.peripherals.EEPROM, 0x3f);
+            pub const EEPROM = @as(*volatile types.peripherals.EEPROM, @ptrFromInt(0x3f));
             ///  Serial Peripheral Interface
-            pub const SPI = @intToPtr(*volatile types.peripherals.SPI, 0x4c);
+            pub const SPI = @as(*volatile types.peripherals.SPI, @ptrFromInt(0x4c));
             ///  Analog Comparator
-            pub const AC = @intToPtr(*volatile types.peripherals.AC, 0x50);
+            pub const AC = @as(*volatile types.peripherals.AC, @ptrFromInt(0x50));
             ///  Watchdog Timer
-            pub const WDT = @intToPtr(*volatile types.peripherals.WDT, 0x60);
+            pub const WDT = @as(*volatile types.peripherals.WDT, @ptrFromInt(0x60));
             ///  Analog-to-Digital Converter
-            pub const ADC = @intToPtr(*volatile types.peripherals.ADC, 0x78);
+            pub const ADC = @as(*volatile types.peripherals.ADC, @ptrFromInt(0x78));
             ///  Two Wire Serial Interface
-            pub const TWI = @intToPtr(*volatile types.peripherals.TWI, 0xb8);
+            pub const TWI = @as(*volatile types.peripherals.TWI, @ptrFromInt(0xb8));
             ///  USART
-            pub const USART0 = @intToPtr(*volatile types.peripherals.USART.USART0, 0xc0);
+            pub const USART0 = @as(*volatile types.peripherals.USART.USART0, @ptrFromInt(0xc0));
         };
     };
 };

--- a/src/hals/ATmega328P.zig
+++ b/src/hals/ATmega328P.zig
@@ -16,6 +16,12 @@ pub const clock = struct {
     };
 };
 
+pub export fn abort() noreturn {
+    while (true) {
+        asm volatile ("nop");
+    }
+}
+
 pub fn parsePin(comptime spec: []const u8) type {
     const invalid_format_msg = "The given pin '" ++ spec ++ "' has an invalid format. Pins must follow the format \"P{Port}{Pin}\" scheme.";
 
@@ -34,14 +40,14 @@ pub const gpio = struct {
     fn regs(comptime desc: type) type {
         return struct {
             // io address
-            const pin_addr: u5 = 3 * @enumToInt(desc.port) + 0x00;
-            const dir_addr: u5 = 3 * @enumToInt(desc.port) + 0x01;
-            const port_addr: u5 = 3 * @enumToInt(desc.port) + 0x02;
+            const pin_addr: u5 = 3 * @intFromEnum(desc.port) + 0x00;
+            const dir_addr: u5 = 3 * @intFromEnum(desc.port) + 0x01;
+            const port_addr: u5 = 3 * @intFromEnum(desc.port) + 0x02;
 
             // ram mapping
-            const pin = @intToPtr(*volatile u8, 0x20 + @as(usize, pin_addr));
-            const dir = @intToPtr(*volatile u8, 0x20 + @as(usize, dir_addr));
-            const port = @intToPtr(*volatile u8, 0x20 + @as(usize, port_addr));
+            const pin = @as(*volatile u8, @ptrFromInt(0x20 + @as(usize, pin_addr)));
+            const dir = @as(*volatile u8, @ptrFromInt(0x20 + @as(usize, dir_addr)));
+            const port = @as(*volatile u8, @ptrFromInt(0x20 + @as(usize, port_addr)));
         };
     }
 
@@ -147,7 +153,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
             USART0.UCSR0B.write(.{
                 .TXB80 = 0, // we don't care about these btw
                 .RXB80 = 0, // we don't care about these btw
-                .UCSZ02 = @truncate(u1, (ucsz & 0x04) >> 2),
+                .UCSZ02 = @as(u1, @truncate((ucsz & 0x04) >> 2)),
                 .TXEN0 = 1,
                 .RXEN0 = 1,
                 .UDRIE0 = 0, // no interrupts
@@ -156,7 +162,7 @@ pub fn Uart(comptime index: usize, comptime pins: micro.uart.Pins) type {
             });
             USART0.UCSR0C.write(.{
                 .UCPOL0 = 0, // async mode
-                .UCSZ0 = @truncate(u2, (ucsz & 0x03) >> 0),
+                .UCSZ0 = @as(u2, @truncate((ucsz & 0x03) >> 0)),
                 .USBS0 = usbs,
                 .UPM0 = upm,
                 .UMSEL0 = umsel,


### PR DESCRIPTION
This PR fixes compilation on Zig master by changing the following:

- ``@XToY()`` to ``@YFromX()``, as well as adding separate calls to ``@as()`` to coerce to the correct type (this was run by ``zig fmt``).
- The ``@breakpoint()`` function (used in MicroZig) now, at least on this specific platform, requires a publicly-exported ``abort()`` function, which wasn't present. I've added a simple abort function.

Additionally, I've removed the LLVM issue warning in the README.md, because, at least, it works fine for me with the latest Zig compiler (when the project is built in Debug mode, as described).